### PR TITLE
Fix lost_iphone service not matching device_name

### DIFF
--- a/icloud.py
+++ b/icloud.py
@@ -382,7 +382,7 @@ class Icloud(object):
         self.api.authenticate()
 
         for device in self.api.devices:
-            if devicename is None or device == self.devices[devicename]:
+            if devicename is None or str(device) == str(self.devices[devicename]):
                 device.play_sound()
 
     def update_icloud(self, devicename=None):


### PR DESCRIPTION
Was unable to trigger lost_iphone service. Found device name would not properly match unless converted to a string first.